### PR TITLE
Fix nasm link in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ $ make
 - https://en.wikipedia.org/wiki/Mode_13h
 - http://www.ctyme.com/intr/int.htm
 
-[nasm]: https://www.nasm.org/
+[nasm]: https://www.nasm.us/
 [qemu]: https://www.qemu.org/


### PR DESCRIPTION
I don't know if it's a meme or just an error, but the `nasm` link points to the fitness web-site currently.