### PR TITLE
The fill_rect procedure now uses a pointer to access rect_x and rect_y data

### DIFF
--- a/pinpog.asm
+++ b/pinpog.asm
@@ -91,18 +91,13 @@ draw_frame:
 
     mov word [rect_width], BALL_WIDTH
     mov word [rect_height], BALL_HEIGHT
-    mov ax, word [ball_x]
-    mov word [rect_x], ax
-    mov ax, word [ball_y]
-    mov word [rect_y], ax
+    mov si, ball_x
     mov ch, BACKGROUND_COLOR
     call fill_rect
 
     mov word [rect_width], BAR_WIDTH
     mov word [rect_height], BAR_HEIGHT
-    mov ax, [bar_x]
-    mov [rect_x], ax
-    mov word [rect_y], HEIGHT - BAR_Y
+    mov si, bar_x
     mov ch, BACKGROUND_COLOR
     call fill_rect
 
@@ -185,18 +180,13 @@ draw_frame:
 
     mov word [rect_width], BALL_WIDTH
     mov word [rect_height], BALL_HEIGHT
-    mov ax, word [ball_x]
-    mov word [rect_x], ax
-    mov ax, word [ball_y]
-    mov word [rect_y], ax
+    mov si, ball_x
     mov ch, BALL_COLOR
     call fill_rect
 
     mov word [rect_width], BAR_WIDTH
     mov word [rect_height], BAR_HEIGHT
-    mov ax, [bar_x]
-    mov [rect_x], ax
-    mov word [rect_y], HEIGHT - BAR_Y
+    mov si, bar_x
     mov ch, BAR_COLOR
     call fill_rect
 
@@ -233,6 +223,7 @@ fill_screen:
 
 fill_rect:
     ;; ch - color
+    ;; si - pointer to ball_x or bar_x
 
     xor ax, ax
     mov ds, ax
@@ -243,11 +234,11 @@ fill_rect:
 .x:
     mov ax, WIDTH
     mov bx, [y]
-    add bx, [rect_y]
+    add bx, [si + 2]
     mul bx
     mov bx, ax
     add bx, [x]
-    add bx, [rect_x]
+    add bx, [si]
     mov BYTE [es: bx], ch
 
     inc word [x]
@@ -275,11 +266,9 @@ ball_dx: dw BALL_VELOCITY
 ball_dy: dw -BALL_VELOCITY
 
 bar_x: dw 10
-bar_y: dw 0
+bar_y: dw HEIGHT - BAR_Y
 bar_dx: dw 10
 
-rect_x: dw 0xcccc
-rect_y: dw 0xcccc
 rect_width: dw 0xcccc
 rect_height: dw 0xcccc
 


### PR DESCRIPTION
This change frees 43 bytes in the bootloader area.