### PR TITLE
Add a beep sound when you score a point (bounce or pin the ball).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ VERSION=1.0
 
 .PHONY: all
 all: pinpog
-	qemu-system-i386 -monitor stdio pinpog
+	qemu-system-i386 -soundhw pcspk -monitor stdio pinpog
 
 pinpog: pinpog.asm
 	nasm pinpog.asm -o pinpog

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $ nasm pinpog.asm -o pinpog
 ### Run the game in QEMU
 
 ```console
-$ qemu-system-i386 pinpog
+$ qemu-system-i386 -soundhw pcspk pinpog
 ```
 
 ## Making Bootable USB stick

--- a/README.release.md
+++ b/README.release.md
@@ -12,7 +12,7 @@ Operating System.
 Install [qemu](https://www.qemu.org/) first.
 
 ```console
-$ qemu-system-i386 pinpog
+$ qemu-system-i386 -soundhw pcspk pinpog
 ```
 
 ## Making Bootable USB stick on Linux


### PR DESCRIPTION
This takes 24 bytes, unless the sound is disabled using the included `%define`, which makes it take no space at all.

The frequency of the sound can be changed using the same `%define`; this sets it as close to the note C3 as I could get with the define, as that sounds fairly OK to my ears.

The beep lasts for almost one frame. If the ball is pinned, though, the beep gets re-triggered in the same frame that it stopped, which makes the sound almost (but not quite) continuous as long as the ball is pinned. In my experience this was not really a problem, and works fairly well as an audible indication of the ball being pinned.

I originally tried to use the print-a-BEL method suggested on the stream, but couldn't get it to work even when using an int10 service that explicitly said that BEL is treated as a control character.

Instead, this drives the PC speaker by controlling the PIT (Programmable Interval Timer) channel that it is connected to. This is a little bit more complicated, but in return allows control over both the frequency and duration of the sound.

Fixes #40
(I know it was set to wontfix, but I don't think this version is too annoying, and it lets you disable the sound if you disagree, so... Up to you.)